### PR TITLE
稍微做了同步

### DIFF
--- a/fs/main.c
+++ b/fs/main.c
@@ -49,6 +49,12 @@ PUBLIC void task_fs()
 		pcaller = &proc_table[src];
 
 		switch (msgtype) {
+		case LS:
+			fs_msg.RETVAL = do_ls();
+			break;
+		case MKDIR:
+			fs_msg.RETVAL = do_mkdir();
+			break;
 		case OPEN:
 			fs_msg.FD = do_open();
 			break;
@@ -71,9 +77,9 @@ PUBLIC void task_fs()
 		case EXIT:
 			fs_msg.RETVAL = fs_exit();
 			break;
-		/* case LSEEK: */
-		/* 	fs_msg.OFFSET = do_lseek(); */
-		/* 	break; */
+		case LSEEK: 
+		 	fs_msg.OFFSET = do_lseek(); 
+		 	break; 
 		case STAT:
 			fs_msg.RETVAL = do_stat();
 			break;


### PR DESCRIPTION
在task_fs()中，增加了对LS消息和MKDIR消息的处理，把"对LSEEK消息的处理"部分的注释去掉了(同济代码里这段是没有被注释掉的，怕以后不一样出问题，就弄出来了)。同济那边注释了STAT,FORK,EXIT的消息处理，但我这里没有注释
和cmd.tar相关的没改（具体的有322行、291行那一坨、252行、360行、361行）
另外，同济那边没有fs_fork()和fs_exit()，但我并没有把这两个函数的实现给注释掉